### PR TITLE
Remove project property from @typescript-eslint/parser options (#6701)

### DIFF
--- a/packages/eslint-config-react-app/index.js
+++ b/packages/eslint-config-react-app/index.js
@@ -23,16 +23,6 @@
 // To use them, explicitly reference them, e.g. `window.name` or `window.status`.
 const restrictedGlobals = require('confusing-browser-globals');
 
-// The following is copied from `react-scripts/config/paths.js`.
-const path = require('path');
-const fs = require('fs');
-// Make sure any symlinks in the project folder are resolved:
-// https://github.com/facebook/create-react-app/issues/637
-const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
-const projectRootPath = resolveApp('.');
-const tsConfigPath = resolveApp('tsconfig.json');
-
 module.exports = {
   root: true,
 
@@ -73,8 +63,6 @@ module.exports = {
       },
 
       // typescript-eslint specific options
-      project: tsConfigPath,
-      tsconfigRootDir: projectRootPath,
       warnOnUnsupportedTypeScriptVersion: true,
     },
     plugins: ['@typescript-eslint'],


### PR DESCRIPTION
* Remove project property from @typescript-eslint/parser options

The "project" property has a significant performance impact on linting,
and none our rules currently need it.

Fixes #6661.

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
